### PR TITLE
Update BMI; fix compile errors

### DIFF
--- a/Child/Code/CMakeLists.txt
+++ b/Child/Code/CMakeLists.txt
@@ -6,6 +6,8 @@ configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/ChildInterface/tests/test_input_file
 
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/child.pc.cmake ${CMAKE_CURRENT_SOURCE_DIR}/child.pc )
 
+set(CMAKE_MACOSX_RPATH 1)
+
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/Erosion

--- a/Child/Code/ChildInterface/bmi_model.h
+++ b/Child/Code/ChildInterface/bmi_model.h
@@ -28,7 +28,6 @@ typedef enum {
 class Model : public Child {
  public:
   Model ();
-  ~Model ();
 
   // Model control functions.
   void Initialize (const char *);

--- a/Child/Code/ChildInterface/bmi_model.h
+++ b/Child/Code/ChildInterface/bmi_model.h
@@ -27,33 +27,8 @@ typedef enum {
 
 class Model : public Child {
  public:
-  Model () {
-    const char *inputs[] = {
-      "land_surface__elevation",
-      "sea_bottom_surface__elevation",
-      "sea_floor_bedrock_surface__elevation",
-      "bedrock_surface__elevation",
-      "bedrock_surface__elevation_increment",
-      NULL,
-    };
-    const char *outputs[] = {
-      "land_surface__elevation",
-      "sea_bottom_surface__elevation",
-      "land_surface__elevation_increment",
-      "sediment__erosion_rate",
-      "channel_water__discharge",
-      "channel_water_sediment~bedload__mass_flow_rate",
-      NULL,
-    };
-    input_var_names = NULL;
-    output_var_names = NULL;
-    SetInputVarNames (inputs);
-    SetOutputVarNames (outputs);
-  }
-  ~Model () {
-    SetInputVarNames (NULL);
-    SetOutputVarNames (NULL);
-  }
+  Model ();
+  ~Model ();
 
   // Model control functions.
   void Initialize (const char *);
@@ -74,6 +49,7 @@ class Model : public Child {
   void GetVarUnits (const char * var_name, char * const units);
   int GetVarItemsize(const char * name);
   int GetVarNbytes(const char * name);
+  void GetVarLocation(const char * name, char * const location);
 
   double GetCurrentTime ();
   double GetStartTime ();
@@ -119,17 +95,24 @@ class Model : public Child {
   void GetGridConnectivity (const int, int * const );
   void GetGridOffset (const int, int * const);
 
+  int GetGridNumberOfEdges(const int);
+  int GetGridNumberOfFaces(const int);
+
+  void GetGridEdgeNodes(const int, int * const);
+  void GetGridFaceEdges(const int, int * const);
+  void GetGridFaceNodes(const int, int * const);
+  void GetGridNodesPerFace(const int, int * const);
+
+
  private:
   bool HasInputVar (const char * var_name);
   bool HasOutputVar (const char * var_name);
-  void SetInputVarNames (const char **names);
-  void SetOutputVarNames (const char **names);
 
   int input_var_name_count;
   int output_var_name_count;
 
-  char** input_var_names;
-  char** output_var_names;
+  char input_var_names[5][2048];
+  char output_var_names[6][2048];
 };
 
 } // namespace bmi

--- a/Child/Code/ChildInterface/child.cpp
+++ b/Child/Code/ChildInterface/child.cpp
@@ -560,10 +560,10 @@ double Child::RunOneStorm() {
   
   time->Advance( stormPlusDryDuration );
 	
-  if( output > 0 && time->CheckOutputTime() )
+  if( output != nullptr && time->CheckOutputTime() )
     output->WriteOutput( time->getCurrentTime() );
 	
-  if( output > 0 && output->OptTSOutput() ) output->WriteTSOutput();
+  if( output != nullptr && output->OptTSOutput() ) output->WriteTSOutput();
   
   return( time->getCurrentTime() );
 }

--- a/Child/Code/ChildInterface/childInterface.cpp
+++ b/Child/Code/ChildInterface/childInterface.cpp
@@ -859,10 +859,10 @@ RunOneStorm()
   
   time->Advance( stormPlusDryDuration );
 	
-  if( output > 0 && time->CheckOutputTime() )
+  if( output != nullptr && time->CheckOutputTime() )
     output->WriteOutput( time->getCurrentTime() );
 	
-  if( output > 0 && output->OptTSOutput() ) output->WriteTSOutput();
+  if( output != nullptr && output->OptTSOutput() ) output->WriteTSOutput();
   
   return( time->getCurrentTime() );
 }
@@ -1174,7 +1174,7 @@ GetXCoordinate( int element_index, int vertex_index )
   tArray2<double> right_hand_voronoi_vertex_coords;
   
   my_node = ni.GetPByPermID( element_index );
-  if( my_node<=0 ) return( -9999 );   // Temporary hacked NODATA code
+  if( my_node == nullptr ) return( -9999 );   // Temporary hacked NODATA code
   
   current_edge = my_node->getEdg();
   if( !current_edge ) return( -9999 );
@@ -1200,7 +1200,7 @@ GetYCoordinate( int element_index, int vertex_index )
   tArray2<double> right_hand_voronoi_vertex_coords;
   
   my_node = ni.GetPByPermID( element_index );
-  if( my_node<=0 ) return( -9999 );   // Temporary hacked NODATA code
+  if( my_node == nullptr ) return( -9999 );   // Temporary hacked NODATA code
   
   current_edge = my_node->getEdg();
   if( !current_edge ) return( -9999 );
@@ -1231,7 +1231,7 @@ GetZCoordinate( int element_index, int vertex_index )
   
   // Get the node
   my_node = ni.GetPByPermID( element_index );
-  if( my_node<=0 ) return( -9999 );   // Temporary hacked NODATA code
+  if( my_node == nullptr ) return( -9999 );   // Temporary hacked NODATA code
   
   // Get the right edge
   current_edge = my_node->getEdg();

--- a/Child/Code/Erosion/erosion.cpp
+++ b/Child/Code/Erosion/erosion.cpp
@@ -2922,7 +2922,7 @@ double tChemicalWeatheringDissolution::SoluteFlux( tLNode * n, double dt )
       lP = lI.PrevP();
       tLayer lay;
       n->getLayersRefNC().removeNext( lay, lI.NodePtr() );
-      assert( n>0 );
+      assert( n != nullptr );
     }
   }
   // multiply by area for total mass flux:
@@ -3164,7 +3164,7 @@ void tDebrisFlow::Initialize( tPtrList<tLNode> &PList,
     // find triangle containing center of mass:
     tTriangle *gt = meshPtr->LocateTriangle( wtAvgX, wtAvgY );
     // if geometric center is within bounds:
-    if( gt>0 )
+    if( gt != nullptr )
     { // find triangle's node with greatest drainage area (and in cluster):
       double gArea = 0.0;
       for( int i=0; i < 3; ++i )
@@ -3466,7 +3466,7 @@ void tDF_ScourAllSediment::BedScour( tDebrisFlow* DF, tLNode* cn )
     cn->ChangeZ( -cl.getDepth() );
   }
   // remove biomass and add to debris flow tally:
-  if( cn->getVegCover().getTrees() > 0 )
+  if( cn->getVegCover().getTrees() != nullptr )
   {
     DF->addWoodVolume( ( cn->getVegCover().getTrees()->getBioMassStand()
                         + cn->getVegCover().getTrees()->getBioMassDown() )
@@ -3533,7 +3533,7 @@ void BuildPublicClusterWithMesh( tMesh<tLNode>* mesh,
 	      tTriangle *ct =  mesh->LocateTriangle( nn->getX(), nn->getY() );
 	      if( nn->public1 == 0 
            && 
-           ct > 0 
+           ct != nullptr 
            && 
            nn->getZ() <= PlaneFit( nn->getX(), nn->getY(), ct ) )
         {
@@ -3952,11 +3952,11 @@ tErosion::~tErosion(){
   delete sedTrans;
   delete physWeath;
   delete chemWeath;
-  if( runout > 0 ) delete runout;
-  if( scour > 0 ) delete scour;
-  if( deposit > 0 ) delete deposit;
-  if( DF_fsPtr > 0 ) delete DF_fsPtr;
-  if( DF_Hyd_fsPtr > 0 ) delete DF_Hyd_fsPtr;
+  if( runout != nullptr ) delete runout;
+  if( scour != nullptr ) delete scour;
+  if( deposit != nullptr ) delete deposit;
+  if( DF_fsPtr != nullptr ) delete DF_fsPtr;
+  if( DF_Hyd_fsPtr != nullptr ) delete DF_Hyd_fsPtr;
 }
 
 /**************************************************************************\
@@ -6471,7 +6471,7 @@ void tErosion::ProduceRegolith( double dtg, double time )
       for( size_t j=0; j<n->getNumg(); ++j ) 
         erolist[j] = soilDeltaH * rockP->getDgrade(j)/rockP->getDepth();
       // is there a soil layer?
-      if( soilP > 0 )
+      if( soilP != nullptr )
         // yes; add material to layer above top rock layer:
         n->EroDep( i-1, erolist, time );
       else
@@ -6599,7 +6599,7 @@ void tErosion::LandslideClusters( double rainrate,
 	 cn=nodIter.NextP(), ++i )
     {
       nodeSoilThickness[i] = cn->getRegolithDepth();
-      if( cn->getVegCover().getTrees() > 0 )
+      if( cn->getVegCover().getTrees() != nullptr )
       {
         nodeWoodDepth[i] = 
 	  cn->getVegCover().getTrees()->getBioMassStand() 
@@ -6678,7 +6678,7 @@ void tErosion::LandslideClusters( double rainrate,
       const double costheta = cos( slopeangle );
       const double sintheta = sin( slopeangle );
       double basalCohesion = 0.0;
-      if( cn->getVegCover().getTrees() > 0 )
+      if( cn->getVegCover().getTrees() != nullptr )
 	basalCohesion = 
 	  cn->getVArea() / costheta
 	  * cn->getVegCover().getTrees()->getRootStrengthVert()
@@ -6996,7 +6996,7 @@ void tErosion::LandslideClusters3D( double rainrate,
 	      nodeSaturatedDepth[i] = nodeSoilThickness[i];
 	    nodeWaterDepth[i] = 
 	      nodeSaturatedDepth[i] * porosity; // water fraction
-	    if( cn->getVegCover().getTrees() > 0 )
+	    if( cn->getVegCover().getTrees() != nullptr )
 	      { // wood depth and root cohesion
 		nodeWoodDepth[i] = 
 		  cn->getVegCover().getTrees()->getBioMassStand() 
@@ -7082,7 +7082,7 @@ void tErosion::LandslideClusters3D( double rainrate,
 		nodeGradientY[i] += 
 		  weightedSlopeByLength * ce->getEVec().at(1);
 		// for lateral cohesion, sum up cohesion along edges:
-		if( cn->getVegCover().getTrees() > 0 )
+		if( cn->getVegCover().getTrees() != nullptr )
 		  nodeLatCohesion[i] += edgeLatCohesion[iEdge];
 	      }
 	    nodeGradientX[i] /= sumWeights;
@@ -7098,7 +7098,7 @@ void tErosion::LandslideClusters3D( double rainrate,
 	    nodeNetForceMag[i] = -nodeLatCohesion[i];
 	    // add basal root cohesion (resistance) to force balance
 	    // (uses flowedge surface slope angle):
-	    if( cn->getVegCover().getTrees() > 0 )
+	    if( cn->getVegCover().getTrees() != nullptr )
 	      nodeNetForceMag[i] -= 
 		cn->getVArea() / costheta
 		* cn->getVegCover().getTrees()->getRootStrengthVert()

--- a/Child/Code/Erosion/erosion.h
+++ b/Child/Code/Erosion/erosion.h
@@ -1000,13 +1000,13 @@ inline tDebrisFlow::~tDebrisFlow() {Finalize();}
 /***************************************************************************/
 inline void tDebrisFlow::Finalize()
 {
-  if( slideCluster > 0 ) delete slideCluster;
-  if( scourCluster > 0 ) delete scourCluster;
-  if( scourZoneMesh > 0 ) delete scourZoneMesh;
-  if( depositCluster > 0 ) delete depositCluster;
-  if( depositZoneMesh > 0 ) delete depositZoneMesh;
-  if( wasList > 0 ) delete wasList;
-  if( velocityList > 0 ) delete velocityList;
+  if( slideCluster != nullptr ) delete slideCluster;
+  if( scourCluster != nullptr ) delete scourCluster;
+  if( scourZoneMesh != nullptr ) delete scourZoneMesh;
+  if( depositCluster != nullptr ) delete depositCluster;
+  if( depositZoneMesh != nullptr ) delete depositZoneMesh;
+  if( wasList != nullptr ) delete wasList;
+  if( velocityList != nullptr ) delete velocityList;
 }
 /***************************************************************************/
 /**
@@ -1069,7 +1069,7 @@ public:
 /***************************************************************************/
 // just checks whether already at outlet or flowing to outlet:
 inline bool tDF_RunOutNoStop::Start( tDebrisFlow *DF )
-{return ( DF->getAtPtr()->getFlowEdg() > 0 && 
+{return ( DF->getAtPtr()->getFlowEdg() != nullptr && 
          DF->getAtPtr()->getFlowEdg()->getDestinationPtr()->isNonBoundary() );}
 
 // just checks whether already at outlet:

--- a/Child/Code/MeshElements/meshElements.cpp
+++ b/Child/Code/MeshElements/meshElements.cpp
@@ -591,9 +591,9 @@ void tNode::ConvertToClosedBoundary()
 **  ...is a debugging routine that prints out a bunch of info about a node.
 **
 \**************************************************************************/
-#ifndef NDEBUG
 void tNode::TellAll() const
 {
+#ifndef NDEBUG
    std::cout << " NODE " << id << ":\n";
    std::cout << "  x=" << x << " y=" << y << " z=" << z;
    std::cout << "  boundary: " << BoundName(boundary)
@@ -601,9 +601,8 @@ void tNode::TellAll() const
    if( edg )
        std::cout << "  points to edg #" << edg->getID() << std::endl;
    else std::cout << "  edg is undefined!\n";
-
-}
 #endif
+}
 
 
 /**************************************************************************\
@@ -1029,9 +1028,9 @@ bool tTriangle::containsPoint(double x, double y) const
 }
 
 /* TellAll: debugging output routine */
-#ifndef NDEBUG
 void tTriangle::TellAll() const
 {
+#ifndef NDEBUG
    int i;
 
    assert( this!=0 );
@@ -1050,7 +1049,7 @@ void tTriangle::TellAll() const
       else std::cout << "(ndef)";
       std::cout << std::endl;
    }
-}
 #endif
+}
 
 

--- a/Child/Code/MeshElements/meshElements.h
+++ b/Child/Code/MeshElements/meshElements.h
@@ -168,9 +168,7 @@ public:
   inline virtual tArray<int> getEdgePtrIndices();
   inline virtual void setEdgePtrsFromVector( vector<tEdge*>& );
 
-#ifndef NDEBUG
    void TellAll() const;  // Debugging routine that outputs node data
-#endif
 
 private:
   static bool freezeElevations; // option for running model without 
@@ -303,9 +301,7 @@ public:
   void setListPtr(void *ptr) { listObj.setListPtr(ptr); }
   void *getListPtr() const { return listObj.getListPtr(); }
 
-#ifndef NDEBUG
   void TellCoords();  // debug routine that reports edge coordinates
-#endif
 
 private:
   tListable        listObj;
@@ -379,9 +375,7 @@ public:
   bool containsPoint(double, double) const; // does "this" contains the point (x,y)
   tTriangle* NbrToward( double, double );
 
-#ifndef NDEBUG
   void TellAll() const;  // debugging routine
-#endif
 
   void setListPtr(void *ptr) { listObj.setListPtr(ptr); }
   void *getListPtr() const { return listObj.getListPtr(); }

--- a/Child/Code/globalFns.cpp
+++ b/Child/Code/globalFns.cpp
@@ -1008,7 +1008,7 @@ int ScanLineNodesByDistance( tLNode *cn, double maxDist,
 	{
 	  closeEnough = false;
 	  tLNode* nxtPtr = ScanLineNextNode( prvPtr, curPtr, abc ); // global fn
-	  if( nxtPtr > 0 && nxtPtr->isNonBoundary() )
+	  if( nxtPtr != nullptr && nxtPtr->isNonBoundary() )
 	    {
 	      leftList.insertAtFront( nxtPtr );
 	      perpDist += fabs( DotProduct2D( curPtr, nxtPtr, uVec ) );
@@ -1036,7 +1036,7 @@ int ScanLineNodesByDistance( tLNode *cn, double maxDist,
 	{
 	  closeEnough = false;
 	  tLNode* nxtPtr = ScanLineNextNode( prvPtr, curPtr, abc ); // global fn
-	  if( nxtPtr > 0 && nxtPtr->isNonBoundary() )
+	  if( nxtPtr != nullptr && nxtPtr->isNonBoundary() )
 	    {
 	      rightList.insertAtBack( nxtPtr );
 	      perpDist += fabs( DotProduct2D( curPtr, nxtPtr, uVec ) );

--- a/Child/Code/tLNode/tLNode.cpp
+++ b/Child/Code/tLNode/tLNode.cpp
@@ -1059,9 +1059,9 @@ double tLNode::DistNew(tLNode const * p0,tLNode const * p1 ) const
  **  ...is a debugging routine that prints out a bunch of info about a node.
  **
 \**************************************************************************/
-#ifndef NDEBUG
 void tLNode::TellAll() const
 {
+#ifndef NDEBUG
   tLNode * nbr;
 
   std::cout << " NODE temp id " << id << " perm id " << permid << ":\n";
@@ -1110,8 +1110,8 @@ void tLNode::TellAll() const
 
   std::cout << "layerlist addresses are:\n";
   layerlist.DebugTellPtrs();
-}
 #endif
+}
 
 
 /**************************************************************************\

--- a/Child/Code/tLNode/tLNode.h
+++ b/Child/Code/tLNode/tLNode.h
@@ -707,9 +707,7 @@ public:
   inline virtual tArray<int> getEdgePtrIndices();
   inline virtual void setEdgePtrsFromVector( vector<tEdge*>& );
 
-#ifndef NDEBUG
   void TellAll() const;
-#endif
 
 protected:
   double CalcSlopeMeander(); // specialisation of CalcSlope()

--- a/Child/Code/tList/tList.h
+++ b/Child/Code/tList/tList.h
@@ -528,9 +528,7 @@ public:
   inline int removePrev( NodeType &, ListNodeType * );
   void Flush();        // clears and reinitializes list
   inline bool isEmpty() const; // returns true is list is empty, false otherwise
-#ifndef NDEBUG
   void print() const;  // prints contents of list - DEBUG ONLY
-#endif
   inline int getSize() const; // returns # of items on list
   inline ListNodeType const * getFirst() const; // returns ptr to 1st list node
   inline ListNodeType const * getLast() const;  // returns ptr to last list node
@@ -553,9 +551,7 @@ public:
   const ListNodeType * getIthListNode( int ) const;
   ListNodeType * getIthListNodeNC( int );
 
-#ifndef NDEBUG
   void DebugTellPtrs() const;
-#endif
 
 protected:
   int nNodes;                          // # of items on list
@@ -970,11 +966,11 @@ isEmpty() const
 }
 
 //display list contents -- for debugging only
-
 template< class NodeType, class ListNodeType >
 void tList< NodeType, ListNodeType >::
 print() const
 {
+#ifndef NDEBUG
   if( isEmpty() )
     {
       std::cout<<"The list is empty\n"<<std::endl;
@@ -987,8 +983,8 @@ print() const
       current = current->next;
     }
   std::cout<< '\n' <<std::endl;
+#endif
 }
-
 
 /**************************************************************************\
  **
@@ -1318,11 +1314,12 @@ makeCircular()
 
 
 template< class NodeType, class ListNodeType >
-void tList< NodeType, ListNodeType >::
-DebugTellPtrs() const
+void tList< NodeType, ListNodeType >::DebugTellPtrs() const
 {
+#ifndef NDEBUG
   std::cout << "first: " << first << std::endl;
   std::cout << "last: " << last << std::endl;
+#endif
 }
 
 

--- a/Child/Code/tMesh/tMesh.cpp
+++ b/Child/Code/tMesh/tMesh.cpp
@@ -1995,7 +1995,7 @@ MakeRandomPointsFromArcGrid( const tInputFile &infile )
     }
   }
   gridfile.close();
-  std::cout << "finished reading file," << gridfile << std::endl;
+  // std::cout << "finished reading file," << gridfile << std::endl;
   // Create the 3 nodes that form the supertriangle and place them on the
   // node list in counter-clockwise order. (Note that the base and height
   // of the supertriangle are 5 times the

--- a/Child/Code/tMesh/tMesh.cpp
+++ b/Child/Code/tMesh/tMesh.cpp
@@ -2745,7 +2745,7 @@ MakeMeshFromPointTilesAndArcGridMask( const tInputFile &infile, tRand &rand )
             if( davlen < oavlen ) cn = dn;
             else cn = on;
           }
-          assert( cn > 0 );
+          assert( cn != nullptr );
           removeList.insertAtBack( cn );
           keepChecking = true;
         }
@@ -4405,7 +4405,7 @@ MakeHullConvex()
       break;
     }
   }
-  assert( bndyedg > 0 );
+  assert( bndyedg != nullptr );
   tPtrList< tSubNode > nbrList;
   tEdge* obedg = bndyedg;
   tSubNode* dn = static_cast<tSubNode*>( bndyedg->getDestinationPtrNC() );

--- a/Child/Code/tStreamNet/tStreamNet.cpp
+++ b/Child/Code/tStreamNet/tStreamNet.cpp
@@ -3276,7 +3276,7 @@ void tStreamNet::FindStreamLines( const tInputFile &infile,
         }
       }
     }
-    if( on > 0 )
+    if( on != nullptr )
     {
       // put streamline nodes in list:
       tLNode *dn = 0;
@@ -3291,7 +3291,7 @@ void tStreamNet::FindStreamLines( const tInputFile &infile,
           if( on->Meanders() ) on->setMeanderStatus( false );
         }
         on = dn;
-      } while( dn > 0 && dn->getBoundaryFlag() == kNonBoundary );
+      } while( dn != nullptr && dn->getBoundaryFlag() == kNonBoundary );
     }
     else
       // shouldn't happen

--- a/Child/Code/tVegetation/tVegetation.cpp
+++ b/Child/Code/tVegetation/tVegetation.cpp
@@ -573,7 +573,7 @@ void tForest::TreeFall( tTrees *tree )
       const double segx = tree->getNodePtr()->getX() + dist * cosangle;
       const double segy = tree->getNodePtr()->getY() + dist * sinangle;
       nt = ct->NbrToward( segx, segy );
-      if( nt > 0 )
+      if( nt != nullptr )
 	ct = nt;
       // find which node to give wood:
       int i;


### PR DESCRIPTION
This pull request update the BMI for Child and fixes some compile errors.

New BMI methods:
* `GetVarLocation`
* `GetGridNumberOfFaces`
* `GetGridNodesPerFace`
* `GetGridFacesNodes`

The compiler errors were mostly due to comparing pointers to integers. This is fixed by using `nullptr` instead of `0`.