### PR TITLE
Add Bmi virtual class

### DIFF
--- a/Child/Code/CMakeLists.txt
+++ b/Child/Code/CMakeLists.txt
@@ -94,7 +94,7 @@ add_executable (bmi_model_child_test ChildInterface/tests/bmi_model_child_test.c
 target_link_libraries (bmi_model_child_test child-shared)
 
 install (FILES
-  ChildInterface/bmi_model.h ChildInterface/child.h
+  ChildInterface/bmi_model.h ChildInterface/child.h ChildInterface/bmi.h
   # ChildInterface/bmi_model_child.h ChildInterface/child.h
   DESTINATION include/child/ChildInterface COMPONENT child)
 install (FILES

--- a/Child/Code/ChildInterface/bmi.h
+++ b/Child/Code/ChildInterface/bmi.h
@@ -1,0 +1,109 @@
+#ifndef BMI_H_
+#define BMI_H_
+
+namespace bmi {
+
+const int MAX_COMPONENT_NAME = 2048;
+const int MAX_VAR_NAME = 2048;
+const int MAX_UNITS_NAME = 2048;
+
+typedef enum {
+  FAILURE = 1,
+  BAD_ARGUMENT,
+  BAD_VAR_NAME,
+  BAD_FILE,
+  CLASS_NOT_INITIALIZED,
+} FatalError;
+
+typedef enum {
+  FUNCTION_NOT_IMPLEMENTED = -1,
+} NonFatalError;
+
+
+class Bmi {
+ public:
+  // Bmi();
+
+  // Model control functions.
+  virtual void Initialize(const char *) = 0;
+  virtual void Update() = 0;
+  virtual void UpdateUntil(double) = 0;
+  virtual void Finalize() = 0;
+
+  // Model information functions.
+  virtual void GetComponentName(char * const name) = 0;
+  virtual int GetInputVarNameCount (void) = 0;
+  virtual int GetOutputVarNameCount (void) = 0;
+  virtual void GetInputVarNames (char * const * const names) = 0;
+  virtual void GetOutputVarNames (char * const * const names) = 0;
+
+  // Variable information functions
+  virtual int GetVarGrid (const char * var_name) = 0;
+  virtual void GetVarType (const char * var_name, char * const vtype) = 0;
+  virtual void GetVarUnits (const char * var_name, char * const units) = 0;
+  virtual int GetVarItemsize(const char * name) = 0;
+  virtual int GetVarNbytes(const char * name) = 0;
+  virtual void GetVarLocation(const char * name, char * const location) = 0;
+
+  virtual double GetCurrentTime () = 0;
+  virtual double GetStartTime () = 0;
+  virtual double GetEndTime () = 0;
+  virtual double GetTimeStep () = 0;
+  virtual void GetTimeUnits (char * const units) = 0;
+
+  // Variable getters
+  virtual void GetValue (const char * var_name, void *) = 0;
+  virtual double * GetValuePtr (const char * var_name) {
+    throw FUNCTION_NOT_IMPLEMENTED;
+    // throw bmi::FUNCTION_NOT_IMPLEMENTED;
+  }
+  virtual void GetValueStride (const char * var_name, int * const stride) {
+    throw FUNCTION_NOT_IMPLEMENTED;
+    //throw bmi::FUNCTION_NOT_IMPLEMENTED;
+  }
+
+  // Variable setters
+  virtual void SetValue (const char *, void *) = 0;
+
+  // Grid information functions
+  virtual void GetGridType (const int grid_id, char * const gtype) = 0;
+  virtual int GetGridRank (const int grid_id) = 0;
+  virtual int GetGridSize (const int grid_id) = 0;
+
+  virtual void GetGridShape (const int, int *) {
+    throw FUNCTION_NOT_IMPLEMENTED;
+    // throw bmi::FUNCTION_NOT_IMPLEMENTED;
+  }
+  virtual void GetGridSpacing (const int, double *) {
+    throw FUNCTION_NOT_IMPLEMENTED;
+    // throw bmi::FUNCTION_NOT_IMPLEMENTED;
+  }
+  virtual void GetGridOrigin (const int, double *) {
+    throw FUNCTION_NOT_IMPLEMENTED;
+    // throw bmi::FUNCTION_NOT_IMPLEMENTED;
+  }
+
+  virtual void GetGridX (const int, double * const) = 0;
+  virtual void GetGridY (const int, double * const) = 0;
+  virtual void GetGridZ (const int, double * const) {
+    throw FUNCTION_NOT_IMPLEMENTED;
+    // throw bmi::FUNCTION_NOT_IMPLEMENTED;
+  }
+
+  virtual int GetGridFaceCount(const int) = 0;
+  virtual int GetGridVertexCount(const int) = 0;
+  virtual void GetGridConnectivity (const int, int * const ) = 0;
+  virtual void GetGridOffset (const int, int * const) = 0;
+
+  virtual int GetGridNumberOfEdges(const int) = 0;
+  virtual int GetGridNumberOfFaces(const int) = 0;
+
+  virtual void GetGridEdgeNodes(const int, int * const) = 0;
+  virtual void GetGridFaceEdges(const int, int * const) = 0;
+  virtual void GetGridFaceNodes(const int, int * const) = 0;
+  virtual void GetGridNodesPerFace(const int, int * const) = 0;
+};
+
+} // namespace bmi
+
+#endif

--- a/Child/Code/ChildInterface/bmi_model.h
+++ b/Child/Code/ChildInterface/bmi_model.h
@@ -1,31 +1,11 @@
 #ifndef CHILD_H_
 #define CHILD_H_
 
-#define BMI_GET_GRID_CONNECTIVITY
-
+#include "bmi.h"
 #include "child.h"
 
 
-namespace bmi {
-
-const int MAX_COMPONENT_NAME = 2048;
-const int MAX_VAR_NAME = 2048;
-const int MAX_UNITS_NAME = 2048;
-
-typedef enum {
-  FAILURE = 1,
-  BAD_ARGUMENT,
-  BAD_VAR_NAME,
-  BAD_FILE,
-  CLASS_NOT_INITIALIZED,
-} FatalError;
-
-typedef enum {
-  FUNCTION_NOT_IMPLEMENTED = -1,
-} NonFatalError;
-
-
-class Model : public Child {
+class Model : public bmi::Bmi {
  public:
   Model ();
 
@@ -58,12 +38,12 @@ class Model : public Child {
 
   // Variable getters
   void GetValue (const char * var_name, void *);
-  double * GetValuePtr (const char * var_name) {
-    throw bmi::FUNCTION_NOT_IMPLEMENTED;
-  }
-  void GetValueStride (const char * var_name, int * const stride) {
-    throw bmi::FUNCTION_NOT_IMPLEMENTED;
-  }
+  // double * GetValuePtr (const char * var_name) {
+  //   throw bmi::FUNCTION_NOT_IMPLEMENTED;
+  // }
+  // void GetValueStride (const char * var_name, int * const stride) {
+  //   throw bmi::FUNCTION_NOT_IMPLEMENTED;
+  // }
 
   // Variable setters
   void SetValue (const char *, void *);
@@ -73,47 +53,43 @@ class Model : public Child {
   int GetGridRank (const int grid_id);
   int GetGridSize (const int grid_id);
 
-  void GetGridShape (const int, int *) {
-    throw bmi::FUNCTION_NOT_IMPLEMENTED;
-  }
-  void GetGridSpacing (const int, double *) {
-    throw bmi::FUNCTION_NOT_IMPLEMENTED;
-  }
-  void GetGridOrigin (const int, double *) {
-    throw bmi::FUNCTION_NOT_IMPLEMENTED;
-  }
+  // void GetGridShape (const int, int *) {
+  //   throw bmi::FUNCTION_NOT_IMPLEMENTED;
+  // }
+  // void GetGridSpacing (const int, double *) {
+  //   throw bmi::FUNCTION_NOT_IMPLEMENTED;
+  // }
+  // void GetGridOrigin (const int, double *) {
+  //   throw bmi::FUNCTION_NOT_IMPLEMENTED;
+  // }
 
   void GetGridX (const int, double * const);
   void GetGridY (const int, double * const);
-  void GetGridZ (const int, double * const) {
-    throw bmi::FUNCTION_NOT_IMPLEMENTED;
-  }
+  // void GetGridZ (const int, double * const) {
+  //   throw bmi::FUNCTION_NOT_IMPLEMENTED;
+  // }
 
   int GetGridFaceCount(const int);
   int GetGridVertexCount(const int);
   void GetGridConnectivity (const int, int * const );
   void GetGridOffset (const int, int * const);
 
-  int GetGridNumberOfEdges(const int);
+  int GetGridNumberOfEdges(const int) { return -1; }
   int GetGridNumberOfFaces(const int);
 
-  void GetGridEdgeNodes(const int, int * const);
-  void GetGridFaceEdges(const int, int * const);
+  void GetGridEdgeNodes(const int, int * const) { }
+  void GetGridFaceEdges(const int, int * const) { }
   void GetGridFaceNodes(const int, int * const);
   void GetGridNodesPerFace(const int, int * const);
 
-
- private:
-  bool HasInputVar (const char * var_name);
-  bool HasOutputVar (const char * var_name);
-
+private:
   int input_var_name_count;
   int output_var_name_count;
 
-  char input_var_names[5][2048];
-  char output_var_names[6][2048];
-};
+  char **input_var_names;
+  char **output_var_names;
 
-} // namespace bmi
+  Child model;
+};
 
 #endif

--- a/Child/Code/ChildInterface/tests/bmi_model_child_test.cpp
+++ b/Child/Code/ChildInterface/tests/bmi_model_child_test.cpp
@@ -23,7 +23,7 @@
 int
 main (int argc, char *argv[])
 {
-  bmi::Model child;
+  Model child;
   char input_file[2048];
 
   if (argc>1)


### PR DESCRIPTION
This pull request cleans up the BMI for Child.
* Added a new `bmi.h` that defines a virtual class for a BMI, which is implemented in `bmi_model.cpp`
* Embed a `Child` object in the BMI implementation instead of using inheritance.
