### PR TITLE
add -std=c++11 to compile flag to allow nullptr

### DIFF
--- a/Child/Bin/gcc.mk
+++ b/Child/Bin/gcc.mk
@@ -17,7 +17,7 @@ WARNINGFLAGS += -Wold-style-cast
 ARCH := 
 # optimise
 #PROFILE = -pg
-CFLAGS = $(WARNINGFLAGS) -g $(PROFILE) -O2 $(ARCH) -c
+CFLAGS = $(WARNINGFLAGS) -g $(PROFILE) -O2 $(ARCH) -std=c++11 -c
 LDFLAGS = $(WARNINGFLAGS) -g $(PROFILE) -O2 $(ARCH)
 # no optimisation, build is faster
 #CFLAGS = $(WARNINGFLAGS) -g $(ARCH) -c


### PR DESCRIPTION
This PR adds the compiler flag -std=c++11, to force compliance with the C++ 11 standard. This is an attempt to solve compiler errors (e.g., with gcc version 4.4.7 20120313 (Red Hat 4.4.7-23) (GCC)) related to the use of nullptr.