### PR TITLE
Fix floating-point exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
 - mamba install cmake cxx-compiler pkg-config -c conda-forge --yes
 script:
 - |
+  cd Child/Code
   mkdir _build && cd _build
   cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release
   make -j$CPU_COUNT all install

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,22 +13,19 @@ before_install:
   fi
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    curl -L https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+    curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > $HOME/miniconda.sh
   else
-    curl -L https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+    curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > $HOME/miniconda.sh
   fi
-- ./bin/micromamba shell init -s bash -p ~/micromamba
-- |
-  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    source $HOME/.bash_profile
-  else
-    source $HOME/.bashrc
-  fi
-- micromamba activate
-- micromamba install mamba --yes -c conda-forge
+- bash $HOME/miniconda.sh -b -p $(pwd)/anaconda
+- export PATH="$(pwd)/anaconda/bin:$PATH"
+- hash -r
+- conda config --set always_yes yes --set changeps1 no
+- conda create -n test_env python=$CONDA_ENV
+- source activate test_env
+- conda info -a && conda list
 install:
-- mamba install cmake cxx-compiler pkg-config -c conda-forge --yes
-- mamba list
+- conda install cmake cxx-compiler pkg-config -c conda-forge --yes
 script:
 - |
   cd Child/Code

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
 - micromamba install mamba --yes -c conda-forge
 install:
 - mamba install cmake cxx-compiler pkg-config -c conda-forge --yes
+- mamba list
 script:
 - |
   cd Child/Code

--- a/Child/Code/.travis.yml
+++ b/Child/Code/.travis.yml
@@ -1,0 +1,38 @@
+language: c++
+os:
+- linux
+- osx
+dist: xenial
+env:
+before_install:
+- |
+  if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+    brew remove --force $(brew list)
+    brew cleanup -s
+    rm -rf $(brew --cache)
+  fi
+- |
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    curl -L https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+  else
+    curl -L https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+  fi
+- ./bin/micromamba shell init -s bash -p ~/micromamba
+- |
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    source $HOME/.bash_profile
+  else
+    source $HOME/.bashrc
+  fi
+- micromamba activate
+- micromamba install mamba --yes -c conda-forge
+install:
+- mamba install cmake cxx-compiler pkg-config -c conda-forge --yes
+script:
+- |
+  mkdir _build && cd _build
+  cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release
+  make -j$CPU_COUNT all install
+  make test
+- child --help
+- child --version

--- a/Child/Code/CMakeLists.txt
+++ b/Child/Code/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 
-ENABLE_TESTING ()
-# ADD_TEST (bmi_model_child_test ${CMAKE_CURRENT_BINARY_DIR}/bmi_model_child_test test_input_files.txt)
+project(CHILD)
+
+ENABLE_TESTING()
 ADD_TEST(
   bmi_model_child_test
   ${CMAKE_CURRENT_BINARY_DIR}/bmi_model_child_test
@@ -12,7 +13,10 @@ configure_file(
   test_input_files.txt
 )
 
-configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/child.pc.cmake ${CMAKE_CURRENT_SOURCE_DIR}/child.pc )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/child.pc.cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/child.pc
+)
 
 set(CMAKE_MACOSX_RPATH 1)
 
@@ -46,12 +50,9 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/tLithologyManager
 )
 
-set (child_LIB_SRCS
+set(child_LIB_SRCS
   ChildInterface/bmi_child.cpp
-  # ChildInterface/bmi_model_child.cpp
   ChildInterface/child.cpp
-  # ChildInterface/childDriver.cpp
-  # ChildInterface/childInterface.cpp
   Erosion/erosion.cpp
   MeshElements/meshElements.cpp
   Mathutil/mathutil.cpp
@@ -81,86 +82,86 @@ set (child_LIB_SRCS
   tLithologyManager/tLithologyManager.cpp
 )
 
-add_library (child-shared SHARED ${child_LIB_SRCS})
-install (TARGETS child-shared DESTINATION lib COMPONENT child)
-set_target_properties (child-shared PROPERTIES OUTPUT_NAME "child")
+add_library(child-shared SHARED ${child_LIB_SRCS})
+install(TARGETS child-shared DESTINATION lib COMPONENT child)
+set_target_properties(child-shared PROPERTIES OUTPUT_NAME "child")
 
-add_library (child-static STATIC ${child_LIB_SRCS})
-set_target_properties (child-static PROPERTIES OUTPUT_NAME "child")
-install (TARGETS child-static DESTINATION lib COMPONENT child)
+add_library(child-static STATIC ${child_LIB_SRCS})
+set_target_properties(child-static PROPERTIES OUTPUT_NAME "child")
+install(TARGETS child-static DESTINATION lib COMPONENT child)
 
-set (child_SRCS ChildInterface/childDriver.cpp ChildInterface/childInterface.cpp)
+set(child_SRCS ChildInterface/childDriver.cpp ChildInterface/childInterface.cpp)
 
-add_executable (child ${child_SRCS})
-target_link_libraries (child child-static)
+add_executable(child ${child_SRCS})
+target_link_libraries(child child-static)
 
 install(FILES child.pc DESTINATION lib/pkgconfig  COMPONENT child)
 
-install (TARGETS child DESTINATION bin COMPONENT child)
+install(TARGETS child DESTINATION bin COMPONENT child)
 
-add_executable (bmi_model_child_test ChildInterface/tests/bmi_model_child_test.cpp)
-target_link_libraries (bmi_model_child_test child-shared)
+add_executable(bmi_model_child_test ChildInterface/tests/bmi_model_child_test.cpp)
+target_link_libraries(bmi_model_child_test child-shared)
 
-install (FILES
-  ChildInterface/bmi_child.hxx ChildInterface/child.h ChildInterface/bmi.hxx
-  # ChildInterface/bmi_model_child.h ChildInterface/child.h
+install(FILES
+  ChildInterface/bmi_child.hxx
+  ChildInterface/child.h ChildInterface/bmi.hxx
   DESTINATION include/child/ChildInterface COMPONENT child)
-install (FILES
+install(FILES
   ChildInterface/childInterface.h
   DESTINATION include/child/ChildInterface COMPONENT child)
-install (FILES
+install(FILES
   Erosion/erosion.h
   DESTINATION include/child/Erosion COMPONENT child)
-install (FILES
+install(FILES
   Geometry/geometry.h
   DESTINATION include/child/Geometry COMPONENT child)
-install (FILES
+install(FILES
   Mathutil/mathutil.h
   DESTINATION include/child/Mathutil COMPONENT child)
-install (FILES
+install(FILES
   tIDGenerator/tIDGenerator.h
   DESTINATION include/child/tIDGenerator COMPONENT child)
-install (FILES
+install(FILES
   MeshElements/meshElements.h
   DESTINATION include/child/MeshElements COMPONENT child)
-install (FILES
+install(FILES
   Predicates/predicates.h
   DESTINATION include/child/Predicates COMPONENT child)
-install (FILES
+install(FILES
   errors/errors.h
   DESTINATION include/child/errors COMPONENT child)
-install (FILES
+install(FILES
   tArray/tArray.h
   tArray/tArray2.h
   tArray/tArray.cpp
   DESTINATION include/child/tArray COMPONENT child)
-install (FILES
+install(FILES
   tEolian/tEolian.h
   DESTINATION include/child/tEolian COMPONENT child)
-install (FILES
+install(FILES
   tFloodplain/tFloodplain.h
   DESTINATION include/child/tFloodplain COMPONENT child)
-install (FILES
+install(FILES
   tInputFile/tInputFile.h
   DESTINATION include/child/tInputFile COMPONENT child)
-install (FILES
+install(FILES
   tLNode/tLNode.h
   DESTINATION include/child/tLNode COMPONENT child)
-install (FILES
+install(FILES
   tList/tList.h
   tList/tListFwd.h
   DESTINATION include/child/tList COMPONENT child)
-install (FILES
+install(FILES
   tListInputData/tListInputData.h
   DESTINATION include/child/tListInputData COMPONENT child)
-install (FILES
+install(FILES
   tLithologyManager/tLithologyManager.h
   DESTINATION include/child/tLithologyManager COMPONENT child)
-install (FILES
+install(FILES
   tMatrix/tMatrix.h
   tMatrix/tMatrix.cpp
   DESTINATION include/child/tMatrix COMPONENT child)
-install (FILES
+install(FILES
   tMesh/ParamMesh_t.h
   tMesh/TipperTriangulator.h
   tMesh/heapsort.h
@@ -168,48 +169,48 @@ install (FILES
   tMesh/tMesh.cpp
   tMesh/tMesh2.cpp
   DESTINATION include/child/tMesh COMPONENT child)
-install (FILES
+install(FILES
   tMeshList/tMeshList.h
   DESTINATION include/child/tMeshList COMPONENT child)
-install (FILES
+install(FILES
   tOption/tOption.h
   DESTINATION include/child/tOption COMPONENT child)
-install (FILES
+install(FILES
   tOutput/tOutput.h
   tOutput/tOutput.cpp
   DESTINATION include/child/tOutput COMPONENT child)
-install (FILES
+install(FILES
   tPtrList/tPtrList.h
   DESTINATION include/child/tPtrList COMPONENT child)
-install (FILES
+install(FILES
   tRunTimer/tRunTimer.h
   DESTINATION include/child/tRunTimer COMPONENT child)
-install (FILES
+install(FILES
   tStorm/tStorm.h
   DESTINATION include/child/tStorm COMPONENT child)
-install (FILES
+install(FILES
   tStratGrid/tStratGrid.h
   DESTINATION include/child/tStratGrid COMPONENT child)
-install (FILES
+install(FILES
   tStreamMeander/meander.h
   tStreamMeander/tStreamMeander.h
   DESTINATION include/child/tStreamMeander COMPONENT child)
-install (FILES
+install(FILES
   tStreamNet/tStreamNet.h
   DESTINATION include/child/tStreamNet COMPONENT child)
-install (FILES
+install(FILES
   tTimeSeries/tTimeSeries.h
   DESTINATION include/child/tTimeSeries COMPONENT child)
-install (FILES
+install(FILES
   tUplift/tUplift.h
   DESTINATION include/child/tUplift COMPONENT child)
-install (FILES
+install(FILES
   tVegetation/tVegetation.h
   DESTINATION include/child/tVegetation COMPONENT child)
-install (FILES
+install(FILES
   tWaterSedTracker/tWaterSedTracker.h
   DESTINATION include/child/tWaterSedTracker COMPONENT child)
-install (FILES
+install(FILES
   Classes.h
   Definitions.h
   trapfpe.h

--- a/Child/Code/CMakeLists.txt
+++ b/Child/Code/CMakeLists.txt
@@ -50,8 +50,8 @@ set (child_LIB_SRCS
   ChildInterface/bmi_child.cpp
   # ChildInterface/bmi_model_child.cpp
   ChildInterface/child.cpp
-  ChildInterface/childDriver.cpp
-  ChildInterface/childInterface.cpp
+  # ChildInterface/childDriver.cpp
+  # ChildInterface/childInterface.cpp
   Erosion/erosion.cpp
   MeshElements/meshElements.cpp
   Mathutil/mathutil.cpp
@@ -89,7 +89,7 @@ add_library (child-static STATIC ${child_LIB_SRCS})
 set_target_properties (child-static PROPERTIES OUTPUT_NAME "child")
 install (TARGETS child-static DESTINATION lib COMPONENT child)
 
-set (child_SRCS ChildInterface/childDriver.cpp)
+set (child_SRCS ChildInterface/childDriver.cpp ChildInterface/childInterface.cpp)
 
 add_executable (child ${child_SRCS})
 target_link_libraries (child child-static)

--- a/Child/Code/ChildInterface/bmi.hxx
+++ b/Child/Code/ChildInterface/bmi.hxx
@@ -1,6 +1,7 @@
 #ifndef BMI_HXX
 #define BMI_HXX
 
+#include <string>
 #include <vector>
 
 

--- a/Child/Code/ChildInterface/bmi_child.hxx
+++ b/Child/Code/ChildInterface/bmi_child.hxx
@@ -1,8 +1,9 @@
 #ifndef BMI_CHILD_H_INCLUDED
 #define BMI_CHILD_H_INCLUDED
 
-#include <string>
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "bmi.hxx"
 #include "child.h"

--- a/Child/Code/ChildInterface/child.cpp
+++ b/Child/Code/ChildInterface/child.cpp
@@ -1,6 +1,12 @@
 #include "child.h"
 
+#include "../tOption/tOption.h"
+
+Predicates predicate;
+
+
 #define VERBOSE (false)
+
 
 void Child::Initialize (std::string argument_string) {
   

--- a/Child/Code/ChildInterface/child.h
+++ b/Child/Code/ChildInterface/child.h
@@ -2,17 +2,23 @@
 #define CHILD_CHILDINTERFACE_CHILD_H_
 
 #include <string>
-#include <sstream>
-#include <vector>
-#include "../trapfpe.h"
-#include "../Inclusions.h"
-#include "../tFloodplain/tFloodplain.h"
-#include "../tStratGrid/tStratGrid.h"
+
+#include "../Erosion/erosion.h"
+#include "../Mathutil/mathutil.h"
 #include "../tEolian/tEolian.h"
-#include "../tOption/tOption.h"
-#include "../tWaterSedTracker/tWaterSedTracker.h"
-#include "../tMeshList/tMeshList.h"
+#include "../tFloodplain/tFloodplain.h"
 #include "../tLithologyManager/tLithologyManager.h"
+#include "../tMesh/tMesh.h"
+#include "../tOutput/tOutput.h"
+#include "../tRunTimer/tRunTimer.h"
+#include "../tStorm/tStorm.h"
+#include "../tStratGrid/tStratGrid.h"
+#include "../tStreamMeander/tStreamMeander.h"
+#include "../tStreamNet/tStreamNet.h"
+#include "../tUplift/tUplift.h"
+#include "../tVegetation/tVegetation.h"
+#include "../tWaterSedTracker/tWaterSedTracker.h"
+
 
 class Child {
   public:
@@ -20,7 +26,7 @@ class Child {
     double RunOneStorm();
     void Run(double run_duration);
     void CleanUp();
-    void MaskNodesBelowElevation(double elev);  // Mask out nodes below elev (eg, sea level)
+    void MaskNodesBelowElevation(double elev);  // Mask out nodes below elev (eg. sea level)
     void CopyNodeElevations (double * const dest);
     void CopyNodeErosion (double * const dest);
     void CopyNodeDischarge (double * const dest);
@@ -28,43 +34,43 @@ class Child {
     void SetNodeElevations (const double * src);
     void SetNodeUplift (const double * src);
   
-    bool initialized;      // Flag indicated whether model has been initialized
-    bool optNoDiffusion,   // Option to turn off diffusive processes (default to false)
-         optNoFluvial,        // Option to turn off fluvial processes (default to false)
-         optNoUplift,       // Option to turn off uplift (default to false) 
-         optDetachLim,      // Option for detachment-limited erosion only
-         optFloodplainDep,  // Option for floodplain (overbank) deposition
-         optLoessDep,       // Option for eolian deposition
-         optVegetation,     // Option for dynamic vegetation cover
-         optFire,           // Option for fire object within tVegetation
-         optForest,         // Option for forest object within tVegetation
-         optMeander,        // Option for stream meandering
-         optDiffuseDepo,    // Option for deposition / no deposition by diff'n
-         optStratGrid,      // Option to enable stratigraphy grid
-         optTrackWaterSedTimeSeries,  // Option to record timeseries Q and Qs
-         optNonlinearDiffusion, // Option for nonlinear creep transport
-         optDepthDependentDiffusion, // Option for depth dependent creep transport
-         optLandslides, // Option for landsliding
-         opt3DLandslides, // Option for determining which landslide function to use
-         optChemicalWeathering, // Option for chemical weathering
-         optPhysicalWeathering; // Option for physical weathering
+    bool initialized;  // Flag indicated whether model has been initialized
+    bool optNoDiffusion;  // Option to turn off diffusive processes (default to false)
+    bool optNoFluvial;  // Option to turn off fluvial processes (default to false)
+    bool optNoUplift;  // Option to turn off uplift (default to false) 
+    bool optDetachLim;  // Option for detachment-limited erosion only
+    bool optFloodplainDep;  // Option for floodplain (overbank) deposition
+    bool optLoessDep;  // Option for eolian deposition
+    bool optVegetation;  // Option for dynamic vegetation cover
+    bool optFire;  // Option for fire object within tVegetation
+    bool optForest;  // Option for forest object within tVegetation
+    bool optMeander;  // Option for stream meandering
+    bool optDiffuseDepo;  // Option for deposition / no deposition by diff'n
+    bool optStratGrid;  // Option to enable stratigraphy grid
+    bool optTrackWaterSedTimeSeries;  // Option to record timeseries Q and Qs
+    bool optNonlinearDiffusion;  // Option for nonlinear creep transport
+    bool optDepthDependentDiffusion;  // Option for depth dependent creep transport
+    bool optLandslides;  // Option for landsliding
+    bool opt3DLandslides;  // Option for determining which landslide function to use
+    bool optChemicalWeathering;  // Option for chemical weathering
+    bool optPhysicalWeathering;  // Option for physical weathering
+    bool optStreamLineBoundary;  // Option for converting streamlines to open boundaries
 
-    bool optStreamLineBoundary; // Option for converting streamlines to open boundaries
-         tRand *rand;             // -> random number generator
-         tMesh<tLNode> *mesh;        // -> mesh object
-         tLOutput<tLNode> *output;   // -> output handler
-         tStorm *storm;              // -> storm generator
-         tStreamNet *strmNet;	    // -> stream network module
-         tErosion *erosion;          // -> erosion module
-         tUplift *uplift;            // -> uplift/baselevel module
-         tRunTimer *time;             // -> run timer
-         tWaterSedTracker water_sed_tracker_;   // Water and sediment tracker
-	       tLithologyManager lithology_manager_;  // Lithology manager
-         tVegetation *vegetation;  // -> vegetation object
-         tFloodplain *floodplain;  // -> floodplain object
-         tStratGrid *stratGrid;     // -> Stratigraphy Grid object
-         tEolian *loess;           // -> eolian deposition object
-         tStreamMeander *strmMeander; // -> stream meander object
+    tRand *rand;             // -> random number generator
+    tMesh<tLNode> *mesh;        // -> mesh object
+    tLOutput<tLNode> *output;   // -> output handler
+    tStorm *storm;              // -> storm generator
+    tStreamNet *strmNet;	    // -> stream network module
+    tErosion *erosion;          // -> erosion module
+    tUplift *uplift;            // -> uplift/baselevel module
+    tRunTimer *time;             // -> run timer
+    tWaterSedTracker water_sed_tracker_;   // Water and sediment tracker
+	  tLithologyManager lithology_manager_;  // Lithology manager
+    tVegetation *vegetation;  // -> vegetation object
+    tFloodplain *floodplain;  // -> floodplain object
+    tStratGrid *stratGrid;     // -> Stratigraphy Grid object
+    tEolian *loess;           // -> eolian deposition object
+    tStreamMeander *strmMeander; // -> stream meander object
 };
 
 #endif

--- a/Child/Code/ChildInterface/tests/bmi_model_child_test.cpp
+++ b/Child/Code/ChildInterface/tests/bmi_model_child_test.cpp
@@ -19,6 +19,9 @@
   } \
 }
 
+Predicates predicate;
+
+
 int
 main (int argc, char *argv[])
 {

--- a/Child/Code/Definitions.h
+++ b/Child/Code/Definitions.h
@@ -13,7 +13,8 @@
 #define DEFINITIONS_H
 
 /** DEFINITIONS *************************************************************/
-#define CHILD_VERSION "9.5.0dev, May 2009"
+#define CHILD_VERSION "20.10.29, October 2020"
+// #define CHILD_VERSION "20.10.29 9.5.0dev, October 2020"
 
 #include <stdlib.h> // abort()
 #include <assert.h>

--- a/Child/Code/tList/tList.h
+++ b/Child/Code/tList/tList.h
@@ -41,8 +41,12 @@
 #ifndef TLIST_H
 #define TLIST_H
 
+#include <assert.h>
+#include <iostream>
+
 #include "tListFwd.h"
 #include "../compiler.h"
+#include "../Definitions.h"
 
 /**************************************************************************/
 /**

--- a/Child/Code/tRunTimer/tRunTimer.h
+++ b/Child/Code/tRunTimer/tRunTimer.h
@@ -18,6 +18,9 @@
 #define TRUNTIMER_H
 
 
+#include <fstream>
+
+
 class tRunTimer
 {
 public:


### PR DESCRIPTION
This pull request, I hope, finally fixes a pesky floating-point exception when running Child through Python (via cython).

The main fix was to ensure that `trapfpe.h` was not being included in `bmi_child.hxx` as it was the source of the floating point exception. This pull request also contains some clean up of includes (i.e. only including necessary files) across the rest of *Child* as well. I've also set up continuous integration with some simple tests (not much more than smoke tests but better than nothing).